### PR TITLE
Fix jq package version name

### DIFF
--- a/v3.8/main.yaml
+++ b/v3.8/main.yaml
@@ -319,7 +319,7 @@ packages:
   - pkg:
       name: jq
       secfixes:
-        1.6rc1-r0:
+        1.6_rc1-r0:
           - CVE-2016-4074
   - pkg:
       name: kamailio


### PR DESCRIPTION
See the correct package version (with underscore) in https://git.alpinelinux.org/cgit/aports/commit/?id=929b5faa3daa8490ac9e97720d28d0435c6936b7