### PR TITLE
change version of jq from rc to release

### DIFF
--- a/v3.9/main.yaml
+++ b/v3.9/main.yaml
@@ -467,7 +467,7 @@ packages:
   - pkg:
       name: jq
       secfixes:
-        1.6_rc1-r0:
+        1.6-r0:
           - CVE-2016-4074
   - pkg:
       name: kamailio


### PR DESCRIPTION
I didn't find any better way to communicate this. In 3.9 the jq package fixing this issue has changed the version name.